### PR TITLE
Updated HereProvider for Geocoder v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: php
 
 php:
-    - 5.3
     - 5.4
     - 5.5
+    - 5.6
+    - 7
     - hhvm
 
 matrix:
     allow_failures:
+        - php: 7
         - php: hhvm
 
 before_script:
     - composer self-update
-    - composer install --dev --prefer-dist --no-interaction
+    - composer install --prefer-dist --no-interaction
 
-script: phpunit --coverage-text
+script: phpunit --coverage-text tests/Geocoder/Tests/Provider/HereProviderTest.php

--- a/src/Geocoder/Provider/HereProvider.php
+++ b/src/Geocoder/Provider/HereProvider.php
@@ -10,16 +10,18 @@
 
 namespace Geocoder\Provider;
 
-use Geocoder\Exception\InvalidCredentialsException;
-use Geocoder\Exception\NoResultException;
-use Geocoder\Exception\UnsupportedException;
-use Geocoder\HttpAdapter\HttpAdapterInterface;
+use Geocoder\Exception\InvalidCredentials as InvalidCredentialsException;
+use Geocoder\Exception\NoResult as NoResultException;
+use Geocoder\Exception\UnsupportedOperation as UnsupportedException;
+use Ivory\HttpAdapter\HttpAdapterInterface;
 
 /**
  * @author Antoine Corcy <contact@sbin.dk>
  */
-class HereProvider extends AbstractProvider implements ProviderInterface
+class HereProvider extends AbstractHttpProvider implements Provider, LocaleAwareProvider
 {
+    use LocaleTrait;
+
     /**
      * @var string
      */
@@ -48,7 +50,11 @@ class HereProvider extends AbstractProvider implements ProviderInterface
      */
     public function __construct(HttpAdapterInterface $adapter, $appId, $appCode, $locale = null)
     {
-        parent::__construct($adapter, $locale);
+        parent::__construct($adapter);
+
+        if ($locale) {
+            $this->setLocale($locale);
+        }
 
         $this->appId   = $appId;
         $this->appCode = $appCode;
@@ -65,10 +71,10 @@ class HereProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getGeocodedData($address)
+    public function geocode($value)
     {
         // This API doesn't handle IPs
-        if (filter_var($address, FILTER_VALIDATE_IP)) {
+        if (filter_var($value, FILTER_VALIDATE_IP)) {
             throw new UnsupportedException('The HereProvider does not support IP addresses.');
         }
 
@@ -78,7 +84,7 @@ class HereProvider extends AbstractProvider implements ProviderInterface
 
         $query = sprintf(
             self::GEOCODE_ENDPOINT_URL,
-            $this->appId, $this->appCode, $this->getMaxResults(), urlencode($address), $this->getLocale()
+            $this->appId, $this->appCode, $this->getLimit(), urlencode($value), $this->getLocale()
         );
 
         return $this->executeQuery($query);
@@ -87,7 +93,7 @@ class HereProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getReversedData(array $coordinates)
+    public function reverse($latitude, $longitude)
     {
         if (null === $this->appId || null === $this->appCode) {
             throw new InvalidCredentialsException('No App ID or code provided.');
@@ -95,7 +101,7 @@ class HereProvider extends AbstractProvider implements ProviderInterface
 
         $query = sprintf(
             self::REVERSE_ENDPOINT_URL,
-            $this->appId, $this->appCode, $this->getMaxResults(), $coordinates[0], $coordinates[1]
+            $this->appId, $this->appCode, $this->getLimit(), $latitude, $longitude
         );
 
         return $this->executeQuery($query);
@@ -109,7 +115,7 @@ class HereProvider extends AbstractProvider implements ProviderInterface
     protected function executeQuery($query)
     {
         $query   = null !== $this->getLocale() ? sprintf('%s&language=%s', $query, $this->getLocale()) : $query;
-        $content = $this->getAdapter()->getContent($query);
+        $content = $this->getAdapter()->get($query)->getBody();
 
         if (!$data = json_decode($content, true)) {
             throw new NoResultException(sprintf('Could not execute query: %s', $query));
@@ -156,6 +162,7 @@ class HereProvider extends AbstractProvider implements ProviderInterface
                 'countryCode'  => isset($address['Country'])     ? $address['Country']     : null,
                 'region'       => $this->findByKey('StateName', $additionalData),
                 'country'      => $this->findByKey('CountryName', $additionalData),
+                'countyCode'   => null,
             ));
         }
 

--- a/tests/Geocoder/Tests/Provider/HereProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/HereProviderTest.php
@@ -19,24 +19,24 @@ class HereProviderTest extends TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testGetGeocodedDataWithNullAppIdAndAppCode()
+    public function testGeocodeWithNullAppIdAndAppCode()
     {
         $provider = new HereProvider($this->getMockAdapter($this->never()), null, null);
-        $provider->getGeocodedData('foo');
+        $provider->geocode('foo');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage http://geocoder.api.here.com/6.2/geocode.json?app_id=app_id&app_code=app_code&maxresults=5&searchtext=bar&gen=6
      */
-    public function testGetGeocodedDataWithAddress()
+    public function testGeocodeWithAddress()
     {
         $provider = new HereProvider($this->getMockAdapter(), 'app_id', 'app_code');
-        $provider->getGeocodedData('bar');
+        $provider->geocode('bar');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\InvalidCredentialsException
+     * @expectedException \Geocoder\Exception\InvalidCredentials
      * @expectedExceptionMessage Invalid credentials: invalid credentials for app_id
      */
     public function testGetInvalidCredentials()
@@ -44,11 +44,11 @@ class HereProviderTest extends TestCase
         $json = '{"details":"invalid credentials for app_id","additionalData":[],"type":"PermissionError","subtype":"InvalidCredentials"}';
 
         $provider = new HereProvider($this->getMockAdapterReturns($json), 'app_id', 'app_code', 'fr-FR');
-        $provider->getGeocodedData('foo');
+        $provider->geocode('foo');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Error type `CustomError` returned from api `custom text`
      */
     public function testGetCustomError()
@@ -56,11 +56,11 @@ class HereProviderTest extends TestCase
         $json = '{"Details":"custom text","additionalData":[],"type":"PermissionError","subtype":"CustomError"}';
 
         $provider = new HereProvider($this->getMockAdapterReturns($json), 'app_id', 'app_code');
-        $provider->getGeocodedData('foo');
+        $provider->geocode('foo');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not find results for given query: http://geocoder.api.here.com/6.2/geocode.json?app_id=app_id&app_code=app_code&maxresults=5&searchtext=foobarbaz&gen=6
      */
     public function testGetEmptyResultsWithWrongAddress()
@@ -68,10 +68,10 @@ class HereProviderTest extends TestCase
         $json = '{"Response":{"MetaInfo":{"Timestamp":"2014-09-13T12:32:57.201+0000"},"View":[]}}';
 
         $provider = new HereProvider($this->getMockAdapterReturns($json), 'app_id', 'app_code');
-        $provider->getGeocodedData('foobarbaz');
+        $provider->geocode('foobarbaz');
     }
 
-    public function testGetGeocodedDataWithRealAddress()
+    public function testGeocodeWithRealAddress()
     {
         if (isset($_SERVER['HERE_APP_ID']) && isset($_SERVER['HERE_APP_CODE'])) {
             $provider = new HereProvider($this->getAdapter(), $_SERVER['HERE_APP_ID'], $_SERVER['HERE_APP_CODE']);
@@ -81,7 +81,7 @@ class HereProviderTest extends TestCase
             $provider = new HereProvider($this->getMockAdapterReturns($json), 'app_id', 'app_code');
         }
 
-        $results  = $provider->getGeocodedData('Copenhagen');
+        $results  = $provider->geocode('Copenhagen');
 
         $this->assertInternalType('array', $results);
         $this->assertCount(1, $results);
@@ -107,26 +107,26 @@ class HereProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
      * @expectedExceptionMessage The HereProvider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithIPv4()
+    public function testGeocodeWithIPv4()
     {
         $provider = new HereProvider($this->getAdapter(), 'app_id', 'app_code');
-        $provider->getGeocodedData('74.200.247.59');
+        $provider->geocode('74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
      * @expectedExceptionMessage The HereProvider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithIPv6()
+    public function testGeocodeWithIPv6()
     {
         $provider = new HereProvider($this->getAdapter(), 'app_id', 'app_code');
-        $provider->getGeocodedData('::ffff:74.200.247.59');
+        $provider->geocode('::ffff:74.200.247.59');
     }
 
-    public function testGetReversedDataWithRealCoordinates()
+    public function testReverseWithRealCoordinates()
     {
         if (isset($_SERVER['HERE_APP_ID']) && isset($_SERVER['HERE_APP_CODE'])) {
             $provider = new HereProvider($this->getAdapter(), $_SERVER['HERE_APP_ID'], $_SERVER['HERE_APP_CODE']);
@@ -136,7 +136,7 @@ class HereProviderTest extends TestCase
             $provider = new HereProvider($this->getMockAdapterReturns($json), 'app_id', 'app_code');
         }
 
-        $results = $provider->getReversedData(array(60.4539471768582, 22.2567842183875));
+        $results = $provider->reverse(60.4539471768582, 22.2567842183875);
 
         $this->assertInternalType('array', $results);
         $this->assertCount(5, $results);


### PR DESCRIPTION
I've updated the HereProvider provider to work with the Geocoder v3 API and the provider's test suite to pass.

In order to have the build confirm the validity of these changes, I've updated the Travis CI configuration such that it's limited to PHP versions supposed by willdurand/geocoder 3.0 and it will for the time being only run the test suite for this provider, since all others in this repo are likely to fail at the moment.