### PR TITLE
Update Baidu, DataScienceToolkit, IGNOpenLS, IpInfo, OGDViennaAustria and OIORest providers for v3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,13 @@ matrix:
         - php: hhvm
 
 before_script:
-    - composer self-update
     - composer install --prefer-dist --no-interaction
 
-script: phpunit --coverage-text tests/Geocoder/Tests/Provider/HereProviderTest.php
+script:
+    - phpunit -c phpunit.xml.dist --coverage-text tests/Geocoder/Tests/Provider/BaiduProviderTest.php
+    - phpunit -c phpunit.xml.dist --coverage-text tests/Geocoder/Tests/Provider/DataScienceToolkitProviderTest.php
+    - phpunit -c phpunit.xml.dist --coverage-text tests/Geocoder/Tests/Provider/HereProviderTest.php
+    - phpunit -c phpunit.xml.dist --coverage-text tests/Geocoder/Tests/Provider/IGNOpenLSProviderTest.php
+    - phpunit -c phpunit.xml.dist --coverage-text tests/Geocoder/Tests/Provider/IpInfoProviderTest.php
+    - phpunit -c phpunit.xml.dist --coverage-text tests/Geocoder/Tests/Provider/OGDViennaAustriaProviderTest.php
+    - phpunit -c phpunit.xml.dist --coverage-text tests/Geocoder/Tests/Provider/OIORestProviderTest.php

--- a/src/Geocoder/Provider/DataScienceToolkitProvider.php
+++ b/src/Geocoder/Provider/DataScienceToolkitProvider.php
@@ -10,13 +10,13 @@
 
 namespace Geocoder\Provider;
 
-use Geocoder\Exception\NoResultException;
-use Geocoder\Exception\UnsupportedException;
+use Geocoder\Exception\NoResult;
+use Geocoder\Exception\UnsupportedOperation;
 
 /**
  * @author Nicolas Chaulet <nchaulet.fr@gmail.com>
  */
-class DataScienceToolkitProvider extends AbstractProvider implements ProviderInterface
+class DataScienceToolkitProvider extends AbstractHttpProvider implements Provider
 {
     /**
      * @var string
@@ -31,14 +31,14 @@ class DataScienceToolkitProvider extends AbstractProvider implements ProviderInt
     /**
      * {@inheritDoc}
      */
-    public function getGeocodedData($address)
+    public function geocode($address)
     {
         if (empty($address)) {
-            throw new UnsupportedException('The DataScienceToolkitProvider does not support empty addresses.');
+            throw new UnsupportedOperation('The DataScienceToolkit provider does not support empty addresses.');
         }
 
         if (filter_var($address, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6)) {
-            throw new UnsupportedException('The DataScienceToolkitProvider does not support IPv6 addresses.');
+            throw new UnsupportedOperation('The DataScienceToolkit provider does not support IPv6 addresses.');
         }
 
         $endpoint = filter_var($address, FILTER_VALIDATE_IP) ? self::ENDPOINT_IP_URL : self::ENDPOINT_ADRESS_URL;
@@ -55,9 +55,9 @@ class DataScienceToolkitProvider extends AbstractProvider implements ProviderInt
     /**
      * {@inheritDoc}
      */
-    public function getReversedData(array $coordinates)
+    public function reverse($latitude, $longitude)
     {
-        throw new UnsupportedException('The DataScienceToolkitProvider is not able to do reverse geocoding.');
+        throw new UnsupportedOperation('The DataScienceToolkit provider is not able to do reverse geocoding.');
     }
 
     /**
@@ -75,11 +75,11 @@ class DataScienceToolkitProvider extends AbstractProvider implements ProviderInt
      */
     protected function executeQuery($query)
     {
-        $content = $this->getAdapter()->getContent($query);
+        $content = (string) $this->getAdapter()->get($query)->getBody();
         $result  = json_decode($content, true);
 
         if (!$result) {
-            throw new NoResultException(sprintf('Could not execute query %s', $query));
+            throw new NoResult(sprintf('Could not execute query %s', $query));
         }
 
         $result = array_shift($result);

--- a/src/Geocoder/Provider/IpInfoProvider.php
+++ b/src/Geocoder/Provider/IpInfoProvider.php
@@ -10,13 +10,13 @@
 
 namespace Geocoder\Provider;
 
-use Geocoder\Exception\UnsupportedException;
-use Geocoder\Exception\NoResultException;
+use Geocoder\Exception\UnsupportedOperation;
+use Geocoder\Exception\NoResult;
 
 /**
  * @author Antoine Corcy <contact@sbin.dk>
  */
-class IpInfoProvider extends AbstractProvider implements ProviderInterface
+class IpInfoProvider extends AbstractHttpProvider implements Provider
 {
     /**
      * @var string
@@ -26,10 +26,10 @@ class IpInfoProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getGeocodedData($address)
+    public function geocode($address)
     {
         if (!filter_var($address, FILTER_VALIDATE_IP)) {
-            throw new UnsupportedException('The IpInfoProvider does not support Street addresses.');
+            throw new UnsupportedOperation('The IpInfo provider does not support Street addresses.');
         }
 
         if (in_array($address, array('127.0.0.1', '::1'))) {
@@ -37,11 +37,11 @@ class IpInfoProvider extends AbstractProvider implements ProviderInterface
         }
 
         $query   = sprintf(self::ENDPOINT_URL, $address);
-        $content = $this->getAdapter()->getContent($query);
+        $content = $this->getAdapter()->get($query)->getBody();
         $data    = json_decode($content, true);
 
         if (empty($data) || !isset($data['loc']) || '' === $data['loc']) {
-            throw new NoResultException(sprintf('Could not execute query %s', $query));
+            throw new NoResult(sprintf('Could not execute query %s', $query));
         }
 
         $location = explode(',', $data['loc']);
@@ -59,9 +59,9 @@ class IpInfoProvider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritDoc}
      */
-    public function getReversedData(array $coordinates)
+    public function reverse($latitude, $longitude)
     {
-        throw new UnsupportedException('The IpInfoProvider is not able to do reverse geocoding.');
+        throw new UnsupportedOperation('The IpInfo provider is not able to do reverse geocoding.');
     }
 
     /**

--- a/src/Geocoder/Provider/OGDViennaAustriaProvider.php
+++ b/src/Geocoder/Provider/OGDViennaAustriaProvider.php
@@ -10,15 +10,15 @@
 
 namespace Geocoder\Provider;
 
-use Geocoder\Exception\UnsupportedException;
-use Geocoder\Exception\NoResultException;
+use Geocoder\Exception\UnsupportedOperation;
+use Geocoder\Exception\NoResult;
 
 /**
  * Data source: City of Vienna, http://data.wien.gv.at
  *
  * @author Robert Harm <www.harm.co.at>
  */
-class OGDViennaAustriaProvider extends AbstractProvider implements ProviderInterface
+class OGDViennaAustriaProvider extends AbstractHttpProvider implements Provider
 {
     /**
      * @var string
@@ -28,11 +28,11 @@ class OGDViennaAustriaProvider extends AbstractProvider implements ProviderInter
     /**
      * {@inheritDoc}
      */
-    public function getGeocodedData($address)
+    public function geocode($address)
     {
         // This API doesn't handle IPs
         if (filter_var($address, FILTER_VALIDATE_IP)) {
-            throw new UnsupportedException('The OGDViennaAustriaProvider does not support IP addresses.');
+            throw new UnsupportedOperation('The OGDViennaAustria provider does not support IP addresses.');
         }
 
         $query = sprintf(self::ENDPOINT_URL, urlencode($address));
@@ -43,9 +43,9 @@ class OGDViennaAustriaProvider extends AbstractProvider implements ProviderInter
     /**
      * {@inheritDoc}
      */
-    public function getReversedData(array $coordinates)
+    public function reverse($latitude, $longitude)
     {
-        throw new UnsupportedException('The OGDViennaAustriaProvider is not able to do reverse geocoding.');
+        throw new UnsupportedOperation('The OGDViennaAustria provider is not able to do reverse geocoding.');
     }
 
     /**
@@ -63,16 +63,16 @@ class OGDViennaAustriaProvider extends AbstractProvider implements ProviderInter
      */
     protected function executeQuery($query)
     {
-        $content = $this->getAdapter()->getContent($query);
+        $content = (string) $this->getAdapter()->get($query)->getBody();
 
         if (empty($content)) {
-            throw new NoResultException(sprintf('Could not execute query %s', $query));
+            throw new NoResult(sprintf('Could not execute query %s', $query));
         }
 
         $data = json_decode($content, true);
 
         if (empty($data) || false === $data) {
-            throw new NoResultException(sprintf('Could not execute query %s', $query));
+            throw new NoResult(sprintf('Could not execute query %s', $query));
         }
 
         $bounds = array(

--- a/tests/Geocoder/Tests/Provider/BaiduProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/BaiduProviderTest.php
@@ -19,80 +19,80 @@ class BaiduProviderTest extends TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testGetGeocodedDataWithNullApiKey()
+    public function testGeocodeWithNullApiKey()
     {
         $provider = new BaiduProvider($this->getMockAdapter($this->never()), null);
-        $provider->getGeocodedData('foo');
+        $provider->geocode('foo');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&address=
      */
-    public function testGetGeocodedDataWithNull()
+    public function testGeocodeWithNull()
     {
         $provider = new BaiduProvider($this->getMockAdapter(), 'api_key');
-        $provider->getGeocodedData(null);
+        $provider->geocode(null);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&address=
      */
-    public function testGetGeocodedDataWithEmpty()
+    public function testGeocodeWithEmpty()
     {
         $provider = new BaiduProvider($this->getMockAdapter(), 'api_key');
-        $provider->getGeocodedData('');
+        $provider->geocode('');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage ould not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&address=%E7%99%BE%E5%BA%A6%E5%A4%A7%E5%8E%A6
      */
-    public function testGetGeocodedDataWithAddressContentReturnNull()
+    public function testGeocodeWithAddressContentReturnNull()
     {
         $provider = new BaiduProvider($this->getMockAdapterReturns(null), 'api_key');
-        $provider->getGeocodedData('百度大厦'); // Baidu Building
+        $provider->geocode('百度大厦'); // Baidu Building
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage ould not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&address=%E7%99%BE%E5%BA%A6%E5%A4%A7%E5%8E%A6
      */
-    public function testGetGeocodedDataWithAddress()
+    public function testGeocodeWithAddress()
     {
         $provider = new BaiduProvider($this->getMockAdapter(), 'api_key');
-        $provider->getGeocodedData('百度大厦'); // Baidu Building
+        $provider->geocode('百度大厦'); // Baidu Building
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The BaiduProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The Baidu provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithLocalhostIPv4()
+    public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new BaiduProvider($this->getMockAdapter($this->never()), 'api_key');
-        $provider->getGeocodedData('127.0.0.1');
+        $provider->geocode('127.0.0.1');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The BaiduProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The Baidu provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithLocalhostIPv6()
+    public function testGeocodeWithLocalhostIPv6()
     {
         $provider = new BaiduProvider($this->getMockAdapter($this->never()), 'api_key');
-        $provider->getGeocodedData('::1');
+        $provider->geocode('::1');
     }
 
-    public function testGetGeocodedDataWithRealAddress()
+    public function testGeocodeWithRealAddress()
     {
         if (!isset($_SERVER['BAIDU_API_KEY'])) {
             $this->markTestSkipped('You need to configure the BAIDU_API_KEY value in phpunit.xml');
         }
 
         $provider = new BaiduProvider($this->getAdapter(), $_SERVER['BAIDU_API_KEY'], 'fr-FR');
-        $result   = $provider->getGeocodedData('上地十街10号 北京市'); // Beijing
+        $result   = $provider->geocode('上地十街10号 北京市'); // Beijing
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -116,43 +116,43 @@ class BaiduProviderTest extends TestCase
     }
 
     /**
-     * @expectedException Geocoder\Exception\NoResultException
+     * @expectedException Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&location=1.000000,2.000000
      */
-    public function testGetReversedData()
+    public function testReverse()
     {
         $provider = new BaiduProvider($this->getMockAdapter(), 'api_key');
-        $provider->getReversedData(array(1, 2));
+        $provider->reverse(1, 2);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\InvalidCredentialsException
+     * @expectedException \Geocoder\Exception\InvalidCredentials
      * @expectedExceptionMessage No API Key provided
      */
-    public function testGetReversedDataWithoutApiKey()
+    public function testReverseWithoutApiKey()
     {
         $provider = new BaiduProvider($this->getMockAdapter($this->never()), null);
-        $provider->getReversedData(array(1, 2));
+        $provider->reverse(1, 2);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&location=39.983424,116.322987
      */
-    public function testGetReversedDataWithCoordinatesContentReturnNull()
+    public function testReverseWithCoordinatesContentReturnNull()
     {
         $provider = new BaiduProvider($this->getMockAdapterReturns(null), 'api_key');
-        $provider->getReversedData(array(39.983424, 116.322987));
+        $provider->reverse(39.983424, 116.322987);
     }
 
-    public function testGetReversedDataWithRealCoordinates()
+    public function testReverseWithRealCoordinates()
     {
         if (!isset($_SERVER['BAIDU_API_KEY'])) {
             $this->markTestSkipped('You need to configure the BAIDU_API_KEY value in phpunit.xml');
         }
 
         $provider = new BaiduProvider($this->getAdapter(), $_SERVER['BAIDU_API_KEY']);
-        $result   = $provider->getReversedData(array(39.983424, 116.322987));
+        $result   = $provider->reverse(39.983424, 116.322987);
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -176,35 +176,35 @@ class BaiduProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The BaiduProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The Baidu provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithRealIPv4()
+    public function testGeocodeWithRealIPv4()
     {
         if (!isset($_SERVER['BAIDU_API_KEY'])) {
             $this->markTestSkipped('You need to configure the BAIDU_API_KEY value in phpunit.xml');
         }
 
         $provider = new BaiduProvider($this->getAdapter(), $_SERVER['BAIDU_API_KEY']);
-        $provider->getGeocodedData('88.188.221.14');
+        $provider->geocode('88.188.221.14');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The BaiduProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The Baidu provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithRealIPv6()
+    public function testGeocodeWithRealIPv6()
     {
         if (!isset($_SERVER['BAIDU_API_KEY'])) {
             $this->markTestSkipped('You need to configure the BAIDU_API_KEY value in phpunit.xml');
         }
 
         $provider = new BaiduProvider($this->getAdapter(), $_SERVER['BAIDU_API_KEY']);
-        $provider->getGeocodedData('::ffff:88.188.221.14');
+        $provider->geocode('::ffff:88.188.221.14');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\InvalidCredentialsException
+     * @expectedException \Geocoder\Exception\InvalidCredentials
      * @expectedExceptionMessage API Key provided is not valid.
      */
     public function testInvalidCredential()
@@ -217,6 +217,6 @@ class BaiduProviderTest extends TestCase
 JSON;
 
         $provider = new BaiduProvider($this->getMockAdapterReturns($json), 'api_key');
-        $provider->getGeocodedData('百度大厦'); // Baidu Building
+        $provider->geocode('百度大厦'); // Baidu Building
     }
 }

--- a/tests/Geocoder/Tests/Provider/DataScienceToolkitProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/DataScienceToolkitProviderTest.php
@@ -14,39 +14,39 @@ class DataScienceToolkitProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The DataScienceToolkitProvider does not support empty addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The DataScienceToolkit provider does not support empty addresses.
      */
-    public function testGetGeocodedDataWithNull()
+    public function testGeocodeWithNull()
     {
         $provider = new DataScienceToolkitProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData(null);
+        $provider->geocode(null);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The DataScienceToolkitProvider does not support empty addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The DataScienceToolkit provider does not support empty addresses.
      */
-    public function testGetGeocodedDataWithEmpty()
+    public function testGeocodeWithEmpty()
     {
         $provider = new DataScienceToolkitProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData('');
+        $provider->geocode('');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://www.datasciencetoolkit.org/street2coordinates/10+rue+de+baraban+lyon
      */
-    public function testGetGeocodedDataWithFrenchAddress()
+    public function testGeocodeWithFrenchAddress()
     {
         $provider = new DataScienceToolkitProvider($this->getMockAdapterReturns(null));
-        $provider->getGeocodedData('10 rue de baraban lyon');
+        $provider->geocode('10 rue de baraban lyon');
     }
 
-    public function testGetGeocodedDataWithLocalhostIPv4()
+    public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new DataScienceToolkitProvider($this->getMockAdapter($this->never()));
-        $result   = $provider->getGeocodedData('127.0.0.1');
+        $result   = $provider->geocode('127.0.0.1');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -57,47 +57,48 @@ class DataScienceToolkitProviderTest extends TestCase
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
         $this->assertArrayNotHasKey('timezone', $result);
+        $this->assertArrayNotHasKey('city', $result);
+        $this->assertArrayNotHasKey('region', $result);
+        $this->assertArrayNotHasKey('county', $result);
 
-        $this->assertEquals('localhost', $result['city']);
-        $this->assertEquals('localhost', $result['region']);
-        $this->assertEquals('localhost', $result['county']);
+        $this->assertEquals('localhost', $result['locality']);
         $this->assertEquals('localhost', $result['country']);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://www.datasciencetoolkit.org/ip2coordinates/81.220.239.218
      */
-    public function testGetGeocodedDataWithRealIPv4GetsNullContent()
+    public function testGeocodeWithRealIPv4GetsNullContent()
     {
         $provider = new DataScienceToolkitProvider($this->getMockAdapterReturns(null));
-        $provider->getGeocodedData('81.220.239.218');
+        $provider->geocode('81.220.239.218');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://www.datasciencetoolkit.org/ip2coordinates/81.220.239.218
      */
-    public function testGetGeocodedDataWithRealIPv4GetsEmptyContent()
+    public function testGeocodeWithRealIPv4GetsEmptyContent()
     {
         $provider = new DataScienceToolkitProvider($this->getMockAdapterReturns(''));
-        $provider->getGeocodedData('81.220.239.218');
+        $provider->geocode('81.220.239.218');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The DataScienceToolkitProvider does not support IPv6 addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The DataScienceToolkit provider does not support IPv6 addresses.
      */
-    public function testGetGeocodedDataWithRealIPv6()
+    public function testGeocodeWithRealIPv6()
     {
         $provider = new DataScienceToolkitProvider($this->getAdapter());
-        $result = $provider->getGeocodedData('::ffff:88.188.221.14');
+        $result = $provider->geocode('::ffff:88.188.221.14');
     }
 
-    public function testGetGeocodedDataWithRealIPv4()
+    public function testGeocodeWithRealIPv4()
     {
         $provider = new DataScienceToolkitProvider($this->getAdapter());
-        $result   = $provider->getGeocodedData('81.220.239.218');
+        $result   = $provider->geocode('81.220.239.218');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -111,10 +112,10 @@ class DataScienceToolkitProviderTest extends TestCase
         $this->assertEquals('FR', $result['countryCode']);
     }
 
-    public function testGetGeocodedDataWithRealAdress()
+    public function testGeocodeWithRealAdress()
     {
         $provider = new DataScienceToolkitProvider($this->getAdapter());
-        $result   = $provider->getGeocodedData('2543 Graystone Place, Simi Valley, CA 93065');
+        $result   = $provider->geocode('2543 Graystone Place, Simi Valley, CA 93065');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -129,12 +130,12 @@ class DataScienceToolkitProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The DataScienceToolkitProvider is not able to do reverse geocoding.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The DataScienceToolkit provider is not able to do reverse geocoding.
      */
-    public function testGetReverseData()
+    public function testReverse()
     {
         $provider = new DataScienceToolkitProvider($this->getMockAdapter($this->never()));
-        $provider->getReversedData(array(1, 2));
+        $provider->reverse(1, 2);
     }
 }

--- a/tests/Geocoder/Tests/Provider/IGNOpenLSProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/IGNOpenLSProviderTest.php
@@ -16,57 +16,57 @@ class IGNOpenLSProviderTest extends TestCase
     /**
      * @expectedException \RuntimeException
      */
-    public function testGetGeocodedDataWithNullApiKey()
+    public function testGeocodeWithNullApiKey()
     {
         $provider = new IGNOpenLSProvider($this->getMockAdapter($this->never()), null);
-        $provider->getGeocodedData('foo');
+        $provider->geocode('foo');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3Efoobar%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
-    public function testGetGeocodedData()
+    public function testGeocode()
     {
         $provider = new IGNOpenLSProvider($this->getMockAdapter(), 'api_key');
-        $provider->getGeocodedData('foobar');
+        $provider->geocode('foobar');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
-    public function testGetGeocodedDataWithNull()
+    public function testGeocodeWithNull()
     {
         $provider = new IGNOpenLSProvider($this->getMockAdapter(), 'api_key');
-        $provider->getGeocodedData(null);
+        $provider->geocode(null);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
-    public function testGetGeocodedDataWithEmpty()
+    public function testGeocodeWithEmpty()
     {
         $provider = new IGNOpenLSProvider($this->getMockAdapter(), 'api_key');
-        $provider->getGeocodedData('');
+        $provider->geocode('');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://gpp3-wxs.ign.fr/api_key/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3E36+Quai+des+Orf%C3%A8vres%2C+Paris%2C+France%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
-    public function testGetGeocodedDataWithAddressGetsNullContent()
+    public function testGeocodeWithAddressGetsNullContent()
     {
         $provider = new IGNOpenLSProvider($this->getMockAdapterReturns(null), 'api_key');
-        $provider->getGeocodedData('36 Quai des Orfèvres, Paris, France');
+        $provider->geocode('36 Quai des Orfèvres, Paris, France');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedMessage Could not execute query http://gpp3-wxs.ign.fr/jqljhusfrcl0c3w1int0dzhd/geoportail/ols?output=xml&xls=%3Cxls%3AXLS+xmlns%3Axls%3D%22http%3A%2F%2Fwww.opengis.net%2Fxls%22+version%3D%221.2%22%3E%3Cxls%3ARequestHeader%2F%3E%3Cxls%3ARequest+methodName%3D%22LocationUtilityService%22+version%3D%221.2%22+maximumResponses%3D%225%22%3E%3Cxls%3AGeocodeRequest+returnFreeForm%3D%22false%22%3E%3Cxls%3AAddress+countryCode%3D%22StreetAddress%22%3E%3Cxls%3AfreeFormAddress%3Efoobar%3C%2Fxls%3AfreeFormAddress%3E%3C%2Fxls%3AAddress%3E%3C%2Fxls%3AGeocodeRequest%3E%3C%2Fxls%3ARequest%3E%3C%2Fxls%3AXLS%3E
      */
-    public function testGetGeocodedDataWithAddressGetsErrorContent()
+    public function testGeocodeWithAddressGetsErrorContent()
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -81,10 +81,10 @@ class IGNOpenLSProviderTest extends TestCase
 XML;
 
         $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($xml), 'api_key');
-        $provider->getGeocodedData('foobar');
+        $provider->geocode('foobar');
     }
 
-    public function testGetGeocodedDataReturnsMultipleResults()
+    public function testGeocodeReturnsMultipleResults()
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -190,7 +190,7 @@ XML;
 XML;
 
         $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($xml), 'api_key');
-        $results  = $provider->getGeocodedData('36 Quai des Orfèvres, 75001 Paris, France');
+        $results  = $provider->geocode('36 Quai des Orfèvres, 75001 Paris, France');
 
         $this->assertInternalType('array', $results);
         $this->assertCount(5, $results);
@@ -218,8 +218,8 @@ XML;
         $this->assertEquals('Europe/Paris', $results[0]['timezone']);
 
         // not provided
-        $this->assertNull($results[0]['region']);
-        $this->assertNull($results[0]['regionCode']);
+        $this->assertArrayNotHasKey('region', $results[0]);
+        $this->assertArrayNotHasKey('regionCode', $results[0]);
 
         $this->assertInternalType('array', $results[1]);
         $this->assertEquals(48.858515, $results[1]['latitude'], '', 0.01);
@@ -276,7 +276,7 @@ XML;
         $this->assertEquals('Paris', $results[4]['city']);
     }
 
-    public function testGetGeocodedDataReturnsSingleResult()
+    public function testGeocodeReturnsSingleResult()
     {
         $xml = <<<XML
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
@@ -310,7 +310,7 @@ XML;
 XML;
 
         $provider = new IGNOpenLSProvider($this->getMockAdapterReturns($xml), 'api_key');
-        $results  = $provider->getGeocodedData('Rue Marconi 57000 Metz');
+        $results  = $provider->geocode('Rue Marconi 57000 Metz');
 
         $this->assertInternalType('array', $results);
         $this->assertCount(1, $results);
@@ -338,18 +338,18 @@ XML;
         $this->assertEquals('Europe/Paris', $result['timezone']);
 
         // not provided
-        $this->assertNull($result['region']);
-        $this->assertNull($result['regionCode']);
+        $this->assertArrayNotHasKey('region', $results[0]);
+        $this->assertArrayNotHasKey('regionCode', $results[0]);
     }
 
-    public function testGetGeocodedDataWithRealAddressReturnsMultipleResults()
+    public function testGeocodeWithRealAddressReturnsMultipleResults()
     {
         if (!isset($_SERVER['IGN_WEB_API_KEY'])) {
             $this->markTestSkipped('You need to configure the IGN_WEB_API_KEY value in phpunit.xml');
         }
 
         $provider = new IGNOpenLSProvider($this->getAdapter(), $_SERVER['IGN_WEB_API_KEY']);
-        $results  = $provider->getGeocodedData('36 Quai des Orfèvres, 75001 Paris, France');
+        $results  = $provider->geocode('36 Quai des Orfèvres, 75001 Paris, France');
 
         $this->assertInternalType('array', $results);
         $this->assertCount(5, $results);
@@ -435,14 +435,14 @@ XML;
         $this->assertEquals('Paris', $results[4]['city']);
     }
 
-    public function testGetGeocodedDataWithRealAddressReturnsSingleResult()
+    public function testGeocodeWithRealAddressReturnsSingleResult()
     {
         if (!isset($_SERVER['IGN_WEB_API_KEY'])) {
             $this->markTestSkipped('You need to configure the IGN_WEB_API_KEY value in phpunit.xml');
         }
 
         $provider = new IGNOpenLSProvider($this->getAdapter(), $_SERVER['IGN_WEB_API_KEY']);
-        $results  = $provider->getGeocodedData('Rue Marconi 57000 Metz');
+        $results  = $provider->geocode('Rue Marconi 57000 Metz');
 
         $this->assertInternalType('array', $results);
         $this->assertCount(1, $results);
@@ -475,52 +475,52 @@ XML;
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IGNOpenLSProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IGNOpenLS provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithLocalhostIPv4()
+    public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new IGNOpenLSProvider($this->getMockAdapter($this->never()), 'api_key');
-        $provider->getGeocodedData('127.0.0.1');
+        $provider->geocode('127.0.0.1');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IGNOpenLSProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IGNOpenLS provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithLocalhostIPv6()
+    public function testGeocodeWithLocalhostIPv6()
     {
         $provider = new IGNOpenLSProvider($this->getMockAdapter($this->never()), 'api_key');
-        $provider->getGeocodedData('::1');
+        $provider->geocode('::1');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IGNOpenLSProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IGNOpenLS provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithIPv4()
+    public function testGeocodeWithIPv4()
     {
         $provider = new IGNOpenLSProvider($this->getAdapter(), 'api_key');
-        $provider->getGeocodedData('74.200.247.59');
+        $provider->geocode('74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IGNOpenLSProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IGNOpenLS provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithIPv6()
+    public function testGeocodeWithIPv6()
     {
         $provider = new IGNOpenLSProvider($this->getAdapter(), 'api_key');
-        $provider->getGeocodedData('::ffff:74.200.247.59');
+        $provider->geocode('::ffff:74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IGNOpenLSProvider is not able to do reverse geocoding.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IGNOpenLS provider is not able to do reverse geocoding.
      */
-    public function testGetReverseData()
+    public function testReverse()
     {
         $provider = new IGNOpenLSProvider($this->getMockAdapter($this->never()), 'api_key');
-        $provider->getReversedData(array(1, 2));
+        $provider->reverse(1, 2);
     }
 }

--- a/tests/Geocoder/Tests/Provider/IpInfoProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/IpInfoProviderTest.php
@@ -14,39 +14,39 @@ class IpInfoProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IpInfoProvider does not support Street addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IpInfo provider does not support Street addresses.
      */
-    public function testGetGeocodedDataWithNull()
+    public function testGeocodeWithNull()
     {
         $provider = new IpInfoProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData(null);
+        $provider->geocode(null);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IpInfoProvider does not support Street addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IpInfo provider does not support Street addresses.
      */
-    public function testGetGeocodedDataWithEmpty()
+    public function testGeocodeWithEmpty()
     {
         $provider = new IpInfoProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData('');
+        $provider->geocode('');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IpInfoProvider does not support Street addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IpInfo provider does not support Street addresses.
      */
-    public function testGetGeocodedDataWithAddress()
+    public function testGeocodeWithAddress()
     {
         $provider = new IpInfoProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData('10 avenue Gambetta, Paris, France');
+        $provider->geocode('10 avenue Gambetta, Paris, France');
     }
 
-    public function testGetGeocodedDataWithLocalhostIPv4()
+    public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new IpInfoProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('127.0.0.1');
+        $result = $provider->geocode('127.0.0.1');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -57,17 +57,18 @@ class IpInfoProviderTest extends TestCase
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
         $this->assertArrayNotHasKey('timezone', $result);
+        $this->assertArrayNotHasKey('city', $result);
+        $this->assertArrayNotHasKey('region', $result);
+        $this->assertArrayNotHasKey('county', $result);
 
-        $this->assertEquals('localhost', $result['city']);
-        $this->assertEquals('localhost', $result['region']);
-        $this->assertEquals('localhost', $result['county']);
+        $this->assertEquals('localhost', $result['locality']);
         $this->assertEquals('localhost', $result['country']);
     }
 
-    public function testGetGeocodedDataWithLocalhostIPv6()
+    public function testGeocodeWithLocalhostIPv6()
     {
         $provider = new IpInfoProvider($this->getMockAdapter($this->never()));
-        $result = $provider->getGeocodedData('::1');
+        $result = $provider->geocode('::1');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -78,34 +79,35 @@ class IpInfoProviderTest extends TestCase
         $this->assertArrayNotHasKey('longitude', $result);
         $this->assertArrayNotHasKey('zipcode', $result);
         $this->assertArrayNotHasKey('timezone', $result);
+        $this->assertArrayNotHasKey('city', $result);
+        $this->assertArrayNotHasKey('region', $result);
+        $this->assertArrayNotHasKey('county', $result);
 
-        $this->assertEquals('localhost', $result['city']);
-        $this->assertEquals('localhost', $result['region']);
-        $this->assertEquals('localhost', $result['county']);
+        $this->assertEquals('localhost', $result['locality']);
         $this->assertEquals('localhost', $result['country']);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://ipinfo.io/74.200.247.59/json
      */
-    public function testGetGeocodedDataWithRealIPv4GetsNullContent()
+    public function testGeocodeWithRealIPv4GetsNullContent()
     {
         $provider = new IpInfoProvider($this->getMockAdapterReturns(null));
-        $provider->getGeocodedData('74.200.247.59');
+        $provider->geocode('74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://ipinfo.io/74.200.247.59/json
      */
-    public function testGetGeocodedDataWithRealIPv4GetsEmptyContent()
+    public function testGeocodeWithRealIPv4GetsEmptyContent()
     {
         $provider = new IpInfoProvider($this->getMockAdapterReturns(''));
-        $provider->getGeocodedData('74.200.247.59');
+        $provider->geocode('74.200.247.59');
     }
 
-    public function testGetGeocodedDataWithRealIPv4()
+    public function testGeocodeWithRealIPv4()
     {
         $json = <<<JSON
 {
@@ -121,7 +123,7 @@ class IpInfoProviderTest extends TestCase
 JSON;
 
         $provider = new IpInfoProvider($this->getMockAdapterReturns($json));
-        $result = $provider->getGeocodedData('74.200.247.59');
+        $result = $provider->geocode('74.200.247.59');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -136,7 +138,7 @@ JSON;
         $this->assertEquals('US', $result['countryCode']);
     }
 
-    public function testGetGeocodedDataWithRealIPv6()
+    public function testGeocodeWithRealIPv6()
     {
         $json = <<<JSON
 {
@@ -152,7 +154,7 @@ JSON;
 JSON;
 
         $provider = new IpInfoProvider($this->getMockAdapterReturns($json));
-        $result = $provider->getGeocodedData('::ffff:74.200.247.59');
+        $result = $provider->geocode('::ffff:74.200.247.59');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -168,10 +170,10 @@ JSON;
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://ipinfo.io/255.255.255.255/json
      */
-    public function testGetGeocodedDataWithoutLocation()
+    public function testGeocodeWithoutLocation()
     {
         $json = <<<JSON
 {
@@ -183,26 +185,26 @@ JSON;
 JSON;
 
         $provider = new IpInfoProvider($this->getMockAdapterReturns($json));
-        $provider->getGeocodedData('255.255.255.255');
+        $provider->geocode('255.255.255.255');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://ipinfo.io/::ffff:74.200.247.59/json
      */
-    public function testGetGeocodedDataWithRealIPv6GetsNullContent()
+    public function testGeocodeWithRealIPv6GetsNullContent()
     {
         $provider = new IpInfoProvider($this->getMockAdapterReturns(null));
-        $provider->getGeocodedData('::ffff:74.200.247.59');
+        $provider->geocode('::ffff:74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The IpInfoProvider is not able to do reverse geocoding.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The IpInfo provider is not able to do reverse geocoding.
      */
-    public function testGetReverseData()
+    public function testReverse()
     {
         $provider = new IpInfoProvider($this->getMockAdapter($this->never()));
-        $provider->getReversedData(array(1, 2));
+        $provider->reverse(1, 2);
     }
 }

--- a/tests/Geocoder/Tests/Provider/OGDViennaAustriaProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/OGDViennaAustriaProviderTest.php
@@ -18,29 +18,29 @@ class OGDViennaAustriaProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://data.wien.gv.at/daten/OGDAddressService.svc/GetAddressInfo?CRS=EPSG:4326&Address=Stephansplatz
      */
-    public function testGetGeocodedDataWithAddress()
+    public function testGeocodeWithAddress()
     {
         $provider = new OGDViennaAustriaProvider($this->getMockAdapter());
-        $provider->getGeocodedData('Stephansplatz');
+        $provider->geocode('Stephansplatz');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://data.wien.gv.at/daten/OGDAddressService.svc/GetAddressInfo?CRS=EPSG:4326&Address=yyyyyyy
      */
-    public function testGetGeocodedDataWithWrongAddress()
+    public function testGeocodeWithWrongAddress()
     {
         $provider = new OGDViennaAustriaProvider($this->getAdapter());
-        $provider->getGeocodedData('yyyyyyy');
+        $provider->geocode('yyyyyyy');
     }
 
-    public function testGetGeocodedDataWithRealAddress()
+    public function testGeocodeWithRealAddress()
     {
         $provider = new OGDViennaAustriaProvider($this->getAdapter());
-        $result   = $provider->getGeocodedData('Stephansplatz');
+        $result   = $provider->geocode('Stephansplatz');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -63,52 +63,52 @@ class OGDViennaAustriaProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OGDViennaAustriaProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OGDViennaAustria provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithLocalhostIPv4()
+    public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new OGDViennaAustriaProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData('127.0.0.1');
+        $provider->geocode('127.0.0.1');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OGDViennaAustriaProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OGDViennaAustria provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithLocalhostIPv6()
+    public function testGeocodeWithLocalhostIPv6()
     {
         $provider = new OGDViennaAustriaProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData('::1');
+        $provider->geocode('::1');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OGDViennaAustriaProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OGDViennaAustria provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithIPv4()
+    public function testGeocodeWithIPv4()
     {
         $provider = new OGDViennaAustriaProvider($this->getAdapter());
-        $provider->getGeocodedData('74.200.247.59');
+        $provider->geocode('74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OGDViennaAustriaProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OGDViennaAustria provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithIPv6()
+    public function testGeocodeWithIPv6()
     {
         $provider = new OGDViennaAustriaProvider($this->getAdapter());
-        $provider->getGeocodedData('::ffff:74.200.247.59');
+        $provider->geocode('::ffff:74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OGDViennaAustriaProvider is not able to do reverse geocoding.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OGDViennaAustria provider is not able to do reverse geocoding.
      */
-    public function testGetReverseData()
+    public function testReverse()
     {
         $provider = new OGDViennaAustriaProvider($this->getMockAdapter($this->never()));
-        $provider->getReversedData(array(1, 2));
+        $provider->reverse(1, 2);
     }
 }

--- a/tests/Geocoder/Tests/Provider/OIORestProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/OIORestProviderTest.php
@@ -8,7 +8,7 @@ use Geocoder\Provider\OIORestProvider;
 /**
  * @author Antoine Corcy <contact@sbin.dk>
  */
-class OIORestProviderTest extends TestCase
+class OIORestTest extends TestCase
 {
     public function testGetName()
     {
@@ -17,49 +17,49 @@ class OIORestProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser.json?q=
      */
-    public function testGetGeocodedDataWithNull()
+    public function testGeocodeWithNull()
     {
         $provider = new OIORestProvider($this->getMockAdapter());
-        $provider->getGeocodedData(null);
+        $provider->geocode(null);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser.json?q=
      */
-    public function testGetGeocodedDataWithEmpty()
+    public function testGeocodeWithEmpty()
     {
         $provider = new OIORestProvider($this->getMockAdapter());
-        $provider->getGeocodedData('');
+        $provider->geocode('');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser.json?q=Tagensvej%2047%2C%202200%20K%C3%B8benhavn%20N
      */
-    public function testGetGeocodedDataWithAddressContentReturnNull()
+    public function testGeocodeWithAddressContentReturnNull()
     {
         $provider = new OIORestProvider($this->getMockAdapterReturns(null));
-        $provider->getGeocodedData('Tagensvej 47, 2200 København N');
+        $provider->geocode('Tagensvej 47, 2200 København N');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser.json?q=Tagensvej%2047%2C%202200%20K%C3%B8benhavn%20N
      */
-    public function testGetGeocodedDataWithAddress()
+    public function testGeocodeWithAddress()
     {
         $provider = new OIORestProvider($this->getMockAdapter());
-        $provider->getGeocodedData('Tagensvej 47, 2200 København N');
+        $provider->geocode('Tagensvej 47, 2200 København N');
     }
 
-    public function testGetGeocodedDataWithRealAddress()
+    public function testGeocodeWithRealAddress()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $result   = $provider->getGeocodedData('Tagensvej 47 2200 København');
+        $result   = $provider->geocode('Tagensvej 47 2200 København');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -68,7 +68,7 @@ class OIORestProviderTest extends TestCase
         $this->assertInternalType('array', $result);
         $this->assertEquals(55.6999, $result['latitude'], '', 0.0001);
         $this->assertEquals(12.5527, $result['longitude'], '', 0.0001);
-        $this->assertNull($result['bounds']);
+        $this->assertSame(array('south' => null, 'west' => null, 'north' => null, 'east' => null), $result['bounds']);
         $this->assertEquals(47, $result['streetNumber']);
         $this->assertEquals('Tagensvej', $result['streetName']);
         $this->assertEquals(2200, $result['zipcode']);
@@ -81,10 +81,10 @@ class OIORestProviderTest extends TestCase
         $this->assertEquals('Europe/Copenhagen', $result['timezone']);
     }
 
-    public function testGetGeocodedDataWithRealAddressAalborg()
+    public function testGeocodeWithRealAddressAalborg()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $result   = $provider->getGeocodedData('Lauritzens Plads 1 9000 Aalborg');
+        $result   = $provider->geocode('Lauritzens Plads 1 9000 Aalborg');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -93,7 +93,7 @@ class OIORestProviderTest extends TestCase
         $this->assertInternalType('array', $result);
         $this->assertEquals(57.0489, $result['latitude'], '', 0.0001);
         $this->assertEquals(9.94566, $result['longitude'], '', 0.0001);
-        $this->assertNull($result['bounds']);
+        $this->assertSame(array('south' => null, 'west' => null, 'north' => null, 'east' => null), $result['bounds']);
         $this->assertEquals(1, $result['streetNumber']);
         $this->assertEquals('Lauritzens Plads', $result['streetName']);
         $this->assertEquals(9000, $result['zipcode']);
@@ -106,10 +106,10 @@ class OIORestProviderTest extends TestCase
         $this->assertEquals('Europe/Copenhagen', $result['timezone']);
     }
 
-    public function testGetGeocodedDataWithRealAddressAarhus()
+    public function testGeocodeWithRealAddressAarhus()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $result   = $provider->getGeocodedData('St.Blichers Vej 74 8210 AArhus');
+        $result   = $provider->geocode('St.Blichers Vej 74 8210 AArhus');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -118,7 +118,7 @@ class OIORestProviderTest extends TestCase
         $this->assertInternalType('array', $result);
         $this->assertEquals(56.1623, $result['latitude'], '', 0.0001);
         $this->assertEquals(10.1501, $result['longitude'], '', 0.0001);
-        $this->assertNull($result['bounds']);
+        $this->assertSame(array('south' => null, 'west' => null, 'north' => null, 'east' => null), $result['bounds']);
         $this->assertEquals(74, $result['streetNumber']);
         $this->assertEquals('St.Blichers Vej', $result['streetName']);
         $this->assertEquals(8210, $result['zipcode']);
@@ -131,10 +131,10 @@ class OIORestProviderTest extends TestCase
         $this->assertEquals('Europe/Copenhagen', $result['timezone']);
     }
 
-    public function testGetGeocodedDataWithRealAddressCopenhagen()
+    public function testGeocodeWithRealAddressCopenhagen()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $result   = $provider->getGeocodedData('Århusgade 80 2100 København');
+        $result   = $provider->geocode('Århusgade 80 2100 København');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -143,7 +143,7 @@ class OIORestProviderTest extends TestCase
         $this->assertInternalType('array', $result);
         $this->assertEquals(55.7063, $result['latitude'], '', 0.0001);
         $this->assertEquals(12.5837, $result['longitude'], '', 0.0001);
-        $this->assertNull($result['bounds']);
+        $this->assertSame(array('south' => null, 'west' => null, 'north' => null, 'east' => null), $result['bounds']);
         $this->assertEquals(80, $result['streetNumber']);
         $this->assertEquals('Århusgade', $result['streetName']);
         $this->assertEquals(2100, $result['zipcode']);
@@ -156,10 +156,10 @@ class OIORestProviderTest extends TestCase
         $this->assertEquals('Europe/Copenhagen', $result['timezone']);
     }
 
-    public function testGetGeocodedDataWithRealAddressOdense()
+    public function testGeocodeWithRealAddressOdense()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $result   = $provider->getGeocodedData('Hvenekildeløkken 255 5240 Odense');
+        $result   = $provider->geocode('Hvenekildeløkken 255 5240 Odense');
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -168,7 +168,7 @@ class OIORestProviderTest extends TestCase
         $this->assertInternalType('array', $result);
         $this->assertEquals(55.4221, $result['latitude'], '', 0.0001);
         $this->assertEquals(10.4588, $result['longitude'], '', 0.0001);
-        $this->assertNull($result['bounds']);
+        $this->assertSame(array('south' => null, 'west' => null, 'north' => null, 'east' => null), $result['bounds']);
         $this->assertEquals(255, $result['streetNumber']);
         $this->assertEquals('Hvenekildeløkken', $result['streetName']);
         $this->assertEquals(5240, $result['zipcode']);
@@ -181,10 +181,10 @@ class OIORestProviderTest extends TestCase
         $this->assertEquals('Europe/Copenhagen', $result['timezone']);
     }
 
-    public function testGetGeocodedDataWithRealAddressReturnsMultipleResults()
+    public function testGeocodeWithRealAddressReturnsMultipleResults()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $results  = $provider->getGeocodedData('Tagensvej 47');
+        $results  = $provider->geocode('Tagensvej 47');
 
         $this->assertInternalType('array', $results);
         $this->assertCount(10, $results);
@@ -192,7 +192,7 @@ class OIORestProviderTest extends TestCase
         $this->assertInternalType('array', $results[0]);
         $this->assertEquals(55.6999504950464, $results[0]['latitude'], '', 0.0001);
         $this->assertEquals(12.552780016775, $results[0]['longitude'], '', 0.0001);
-        $this->assertNull($results[0]['bounds']);
+        $this->assertSame(array('south' => null, 'west' => null, 'north' => null, 'east' => null), $results[0]['bounds']);
         $this->assertEquals(47, $results[0]['streetNumber']);
         $this->assertEquals('Tagensvej', $results[0]['streetName']);
         $this->assertEquals(2200, $results[0]['zipcode']);
@@ -287,79 +287,79 @@ class OIORestProviderTest extends TestCase
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OIORestProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OIORest provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithLocalhostIPv4()
+    public function testGeocodeWithLocalhostIPv4()
     {
         $provider = new OIORestProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData('127.0.0.1');
+        $provider->geocode('127.0.0.1');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OIORestProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OIORest provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithLocalhostIPv6()
+    public function testGeocodeWithLocalhostIPv6()
     {
         $provider = new OIORestProvider($this->getMockAdapter($this->never()));
-        $provider->getGeocodedData('::1');
+        $provider->geocode('::1');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OIORestProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OIORest provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithIPv4()
+    public function testGeocodeWithIPv4()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $provider->getGeocodedData('74.200.247.59');
+        $provider->geocode('74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\UnsupportedException
-     * @expectedExceptionMessage The OIORestProvider does not support IP addresses.
+     * @expectedException \Geocoder\Exception\UnsupportedOperation
+     * @expectedExceptionMessage The OIORest provider does not support IP addresses.
      */
-    public function testGetGeocodedDataWithIPv6()
+    public function testGeocodeWithIPv6()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $provider->getGeocodedData('::ffff:74.200.247.59');
+        $provider->geocode('::ffff:74.200.247.59');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser/1.000000,2.000000.json
      */
-    public function testGetReverseData()
+    public function testReverse()
     {
         $provider = new OIORestProvider($this->getMockAdapter());
-        $provider->getReversedData(array(1, 2));
+        $provider->reverse(1, 2);
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser/60.453947,22.256784.json
      */
-    public function testGetReversedDataWithCoordinatesGetsNullContent()
+    public function testReverseWithCoordinatesGetsNullContent()
     {
         $provider = new OIORestProvider($this->getMockAdapterReturns(null));
-        $provider->getReversedData(array('60.4539471728726', '22.2567841926781'));
+        $provider->reverse('60.4539471728726', '22.2567841926781');
     }
 
     /**
-     * @expectedException \Geocoder\Exception\NoResultException
+     * @expectedException \Geocoder\Exception\NoResult
      * @expectedExceptionMessage Could not execute query http://geo.oiorest.dk/adresser/60.453947,22.256784.json
      */
-    public function testGetReversedDataWithCoordinatesGetsEmptyContent()
+    public function testReverseWithCoordinatesGetsEmptyContent()
     {
         $provider = new OIORestProvider($this->getMockAdapterReturns(''));
-        $provider->getReversedData(array('60.4539471728726', '22.2567841926781'));
+        $provider->reverse('60.4539471728726', '22.2567841926781');
     }
 
-    public function testGetGeocodedDataWithRealCoordinates()
+    public function testGeocodeWithRealCoordinates()
     {
         $provider = new OIORestProvider($this->getAdapter());
-        $result = $provider->getReversedData(array(56.5231, 10.0659));
+        $result = $provider->reverse(56.5231, 10.0659);
 
         $this->assertInternalType('array', $result);
         $this->assertCount(1, $result);
@@ -368,7 +368,7 @@ class OIORestProviderTest extends TestCase
         $this->assertInternalType('array', $result);
         $this->assertEquals(56.521542795662, $result['latitude'], '', 0.0001);
         $this->assertEquals(10.0668558607917, $result['longitude'], '', 0.0001);
-        $this->assertNull($result['bounds']);
+        $this->assertSame(array('south' => null, 'west' => null, 'north' => null, 'east' => null), $result['bounds']);
         $this->assertEquals(11, $result['streetNumber']);
         $this->assertEquals('Stabelsvej', $result['streetName']);
         $this->assertEquals(8981, $result['zipcode']);


### PR DESCRIPTION
Some providers have not been updated:
 - IpGeoBase
 - GeocoderCA
 - GeocoderUS
 - Geocodio
 - Naver
 - Telize

these have fixtures that fails (might be already failing in version 2.0) and needs investigation
