### PR TITLE
Fix broken unit tests for Baidu (via PR #33)

### DIFF
--- a/src/Geocoder/Provider/BaiduProvider.php
+++ b/src/Geocoder/Provider/BaiduProvider.php
@@ -23,12 +23,12 @@ class BaiduProvider extends AbstractProvider implements ProviderInterface
     /**
      * @var string
      */
-    const GEOCODE_ENDPOINT_URL = 'http://api.map.baidu.com/geocoder?output=json&key=%s&address=%s';
+    const GEOCODE_ENDPOINT_URL = 'http://api.map.baidu.com/geocoder/v2/?output=json&pois=0&ak=%s&address=%s';
 
     /**
      * @var string
      */
-    const REVERSE_ENDPOINT_URL = 'http://api.map.baidu.com/geocoder?output=json&key=%s&location=%F,%F';
+    const REVERSE_ENDPOINT_URL = 'http://api.map.baidu.com/geocoder/v2/?output=json&pois=0&ak=%s&location=%F,%F';
 
     /**
      * @var string

--- a/tests/Geocoder/Tests/Provider/BaiduProviderTest.php
+++ b/tests/Geocoder/Tests/Provider/BaiduProviderTest.php
@@ -27,7 +27,7 @@ class BaiduProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&address=
+     * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder/v2/?output=json&pois=0&ak=api_key&address=
      */
     public function testGeocodeWithNull()
     {
@@ -37,7 +37,7 @@ class BaiduProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&address=
+     * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder/v2/?output=json&pois=0&ak=api_key&address=
      */
     public function testGeocodeWithEmpty()
     {
@@ -47,7 +47,7 @@ class BaiduProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage ould not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&address=%E7%99%BE%E5%BA%A6%E5%A4%A7%E5%8E%A6
+     * @expectedExceptionMessage ould not execute query http://api.map.baidu.com/geocoder/v2/?output=json&pois=0&ak=api_key&address=%E7%99%BE%E5%BA%A6%E5%A4%A7%E5%8E%A6
      */
     public function testGeocodeWithAddressContentReturnNull()
     {
@@ -57,7 +57,7 @@ class BaiduProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage ould not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&address=%E7%99%BE%E5%BA%A6%E5%A4%A7%E5%8E%A6
+     * @expectedExceptionMessage ould not execute query http://api.map.baidu.com/geocoder/v2/?output=json&pois=0&ak=api_key&address=%E7%99%BE%E5%BA%A6%E5%A4%A7%E5%8E%A6
      */
     public function testGeocodeWithAddress()
     {
@@ -117,7 +117,7 @@ class BaiduProviderTest extends TestCase
 
     /**
      * @expectedException Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&location=1.000000,2.000000
+     * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder/v2/?output=json&pois=0&ak=api_key&location=1.000000,2.000000
      */
     public function testReverse()
     {
@@ -137,7 +137,7 @@ class BaiduProviderTest extends TestCase
 
     /**
      * @expectedException \Geocoder\Exception\NoResult
-     * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder?output=json&key=api_key&location=39.983424,116.322987
+     * @expectedExceptionMessage Could not execute query http://api.map.baidu.com/geocoder/v2/?output=json&pois=0&ak=api_key&location=39.983424,116.322987
      */
     public function testReverseWithCoordinatesContentReturnNull()
     {


### PR DESCRIPTION
As noted in https://github.com/geocoder-php/geocoder-extra/pull/33#issuecomment-253728021, the pull request as submitted broke the unit tests. This PR incorporates the code changes to `BaiduProvider.php` as well as fixing up the unit tests as a result of the changed endpoint URLs for v2 of Baidu's geocoding API.
